### PR TITLE
Adding additional command to get supported Kubernetes version

### DIFF
--- a/01-cluster/readme.md
+++ b/01-cluster/readme.md
@@ -17,7 +17,7 @@ az aks create --resource-group $RES_GROUP \
   --name $AKS_NAME \
   --location $REGION \
   --node-count 2 --node-vm-size Standard_B2ms \
-  --kubernetes-version 1.23.8 \
+  --kubernetes-version 1.25.5 \
   --verbose
 ```
 In case you get an error when creating cluster, `Version x.xx.x is not supported in this region.`, run the following to get the supported kubernetes version

--- a/01-cluster/readme.md
+++ b/01-cluster/readme.md
@@ -17,9 +17,14 @@ az aks create --resource-group $RES_GROUP \
   --name $AKS_NAME \
   --location $REGION \
   --node-count 2 --node-vm-size Standard_B2ms \
-  --kubernetes-version 1.22.4 \
+  --kubernetes-version 1.23.8 \
   --verbose
 ```
+In case you get an error when creating cluster, `Version x.xx.x is not supported in this region.`, run the following to get the supported kubernetes version
+```
+az aks get-versions --location $REGION -o table
+```
+And re-run the create cluster command with supported version number. 
 
 This should take around 5 minutes to complete, and creates a new AKS cluster with the following
 characteristics:


### PR DESCRIPTION
The Kubernetes version might not be supported in a given region and the `az aks create` command might throw an error, so adding additional command that can help to get the supported version for the region
