### PR TITLE
Updated ingress.yaml and added resources to install prerequisites in Windows

### DIFF
--- a/00-pre-reqs/readme.md
+++ b/00-pre-reqs/readme.md
@@ -26,6 +26,12 @@ On MacOS, use homebrew:
 brew update && brew install azure-cli
 ```
 
+On Windows, open Powershell as administrator and run:
+
+```bash
+$ProgressPreference = 'SilentlyContinue'; Invoke-WebRequest -Uri https://aka.ms/installazurecliwindows -OutFile .\AzureCLI.msi; Start-Process msiexec.exe -Wait -ArgumentList '/I AzureCLI.msi /quiet'; Remove-Item .\AzureCLI.msi
+```
+
 If the commands above don't work, please refer to: [https://aka.ms/azure-cli](https://aka.ms/azure-cli)
 
 ## ⛑️ Install Helm & Kubectl
@@ -69,6 +75,14 @@ sudo mv ./kubectl /usr/local/bin/kubectl
 # Install Helm
 curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
 ```
+
+</details>
+
+<details markdown="1">
+<summary>Install Helm & Kubectl - Windows</summary>
+
+To install Kubectl in Windows follow one of the two approached given [here](https://kubernetes.io/docs/tasks/tools/install-kubectl-windows/#install-kubectl-on-windows).
+For Helm, follow the approach given [here](https://helm.sh/docs/intro/install/).
 
 </details>
 

--- a/07-improvements/readme.md
+++ b/07-improvements/readme.md
@@ -112,7 +112,7 @@ _Secrets_ can contain multiple keys, here we add two keys one for the password c
 and one for the connection string called `connection-string`, both reside in the new _Secret_ called
 `mongo-creds`.
 
-_Secrets_ can use used a number of ways, but the easiest way is to consume them, is as environmental
+_Secrets_ can be used a number of ways, but the easiest way to consume them, is as environmental
 variables passed into your containers. Update the deployment YAML for your data API, and MongoDB,
 replace the references to `MONGO_INITDB_ROOT_PASSWORD` and `MONGO_CONNSTR` as shown below:
 

--- a/08-helm-ingress/readme.md
+++ b/08-helm-ingress/readme.md
@@ -138,10 +138,6 @@ metadata:
     name: my-app
 
 spec:
-  # Important we leave this blank, as we don't have DNS configured
-  # Blank means these rules will match ALL HTTP requests hitting the controller IP
-  host:
-  # This is important and required since Kubernetes 1.22
   ingressClassName: nginx
   rules:
     - http:


### PR DESCRIPTION
Made the following updates in the PR:
- Fix: removed host from ingress.yaml to deal with the 'unknown field spec.host' error. 'host' is moved to spec.rules now. 
![image](https://user-images.githubusercontent.com/23461501/223250669-7cf75876-65b4-491e-8c01-4dd3dda6a13a.png)
- Added approaches/links to install azurecli, kubctl and helm for windows
 