### PR TITLE
Update dependencies and enhance Kube Workshop

### DIFF
--- a/.github/workflows/ci-build-deploy.yaml
+++ b/.github/workflows/ci-build-deploy.yaml
@@ -43,13 +43,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
 
@@ -60,10 +60,10 @@ jobs:
         run: npm run build
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: "_site"
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/content/00-pre-reqs/index.md
+++ b/content/00-pre-reqs/index.md
@@ -166,7 +166,7 @@ RES_GROUP="kube-workshop"
 REGION="westeurope"
 AKS_NAME="__change_me__"
 ACR_NAME="__change_me__"
-KUBE_VERSION="1.33.6"
+KUBE_VERSION="1.36"
 ```
 
 > New versions of Kubernetes are released all the time, and eventually older versions are removed from Azure. Rather

--- a/content/00-pre-reqs/vars.sh.sample
+++ b/content/00-pre-reqs/vars.sh.sample
@@ -2,7 +2,7 @@ RES_GROUP="kube-workshop"
 REGION="westeurope"
 AKS_NAME="__change_me__"
 ACR_NAME="__change_me__" # NOTE: Can not contain underscores or hyphens
-KUBE_VERSION="1.33.6"
+KUBE_VERSION="1.36"
 
 # Do not edit below this line
 

--- a/content/01-cluster/index.md
+++ b/content/01-cluster/index.md
@@ -10,7 +10,8 @@ icon: 🚀
 # {{ icon }} {{ title }}
 
 Deploying AKS and Kubernetes can be extremely complex, with many networking, compute and other aspects to consider.
-However for the purposes of this workshop, a default and basic cluster can be deployed very quickly.
+However for the purposes of this workshop, a default and basic cluster can be deployed very quickly using Azure and the
+[Azure Kubernetes Service (AKS)](https://learn.microsoft.com/en-us/azure/aks/what-is-aks).
 
 ## 🔨 AKS Cluster Deployment
 
@@ -90,8 +91,8 @@ To enable `kubectl` (and other tools) to access the cluster, run the following:
 az aks get-credentials --name $AKS_NAME --resource-group $RES_GROUP
 ```
 
-This will create Kubernetes config file in your home directory `~/.kube/config` which is the default location, used by
-`kubectl`.
+This will connect to Azure to get the credentials needed to connect and work with your cluster. It will create a
+Kubernetes config file in your home directory `~/.kube/config` which is the default location, used by `kubectl`.
 
 Now you can run some simple `kubectl` commands to validate the health and status of your cluster:
 

--- a/content/03-the-application/index.md
+++ b/content/03-the-application/index.md
@@ -16,7 +16,8 @@ hosted any container based system e.g. Kubernetes or various cloud services, or 
 
 > We have no particular interest in the features of Nanomon or actually using it! It has been selected as representing a
 > good example application to deploy, given it has multiple components, and is fairly indicative of many of the
-> applications & systems you might find yourself running in Kubernetes.
+> applications & systems you might find yourself running in Kubernetes. It was developed as a side project by the author
+> of this workshop, and was created in part to provide a suitable example application for this workshop.
 
 Project link: [Nanomon - GitHub Repo & Project](https://github.com/benc-uk/nanomon)
 

--- a/content/09-helm-ingress/index.md
+++ b/content/09-helm-ingress/index.md
@@ -11,10 +11,10 @@ icon: 🌎
 
 🔥 At this point in the workshop you have a choice:
 
-- If you want to learn about the legacy Ingress API, continue with this section. This is widely supported and in wide
-  use, but it has been superseded in functionallity by the newer Gateway API.
-- If you want to learn about the new Gateway API, which is still evolving but represents the future of L4/L7 routing in
+- _Recommended_: If you want to learn about the new Gateway API, which represents the future of L4/L7 routing in
   Kubernetes, go to the [Helm & Gateway API section](../09a-helm-gateway-api/).
+- _Not recommended_: If you want to learn about the legacy Ingress API, continue with this section. This is widely
+  supported and in wide use, but it has been superseded in functionality by the newer Gateway API.
 
 Only go through one of these two sections, not both!
 

--- a/content/index.md
+++ b/content/index.md
@@ -5,31 +5,36 @@ layout: default.njk
 
 # Kubernetes Developer Workshop
 
-Welcome to the 'Kubernetes Developer Workshop', a highly technical & hands on set of exercises intended to get you
-comfortable working with Kubernetes, and deploying applications within it. This workshop is very much aimed at software
-engineers & developers with little or zero Kubernetes experience, but wanting to get hands on and learn how to deploy
-and manage their code in a Kubernetes.
+Welcome to the 'Kubernetes Developer Workshop'. This isn't a lecture or a pile of theory to read through, it's a set of
+hands on exercises where you'll actually deploy and run a real application on Kubernetes. You'll spend your time in the
+terminal and working with live clusters, building up genuine, practical experience as you go.
 
-It should take roughly 6~8 hours to complete the main set of sections, but this is very approximate. This
-[Kubernetes Technical Primer](https://github.com/benc-uk/kube-primer) can act as a companion to the workshop to be read
-through, referenced or used to get an initial grounding on the concepts.
+It's aimed at software engineers and developers with little or zero Kubernetes experience who want to roll up their
+sleeves and learn by doing, rather than just reading about it. By the end you'll have real, hands on experience of
+deploying and managing your code in Kubernetes.
 
-The installation, administration, network configuration & day-2 operations of Kubernetes itself, are not covered in this
-workshop. This is very much a developer focused workshop, so if you want to learn about the low level & operational side
-of Kubernetes you might want to look elsewhere.
+Although it's called a workshop, the name is a little misleading. It's flexible in how you use it, it can be run as a
+guided workshop or training session, alternatively work through it at your own pace as self-paced learning, or just dip
+into individual sections as a reference guide when you need them.
 
-The workshop focuses on an application that has already been written and built, so no application code will need to be
-written.
+Plan for roughly 6 to 8 hours to get through the main sections, though that's a rough guide so go at your own pace. If
+you want some background reading alongside it, the [Kubernetes Technical Primer](https://github.com/benc-uk/kube-primer)
+makes a handy companion for grounding yourself in the concepts.
 
-If you get stuck, the [GitHub source repo for this workshop](https://github.com/benc-uk/kube-workshop) contains example
-code, and working files for all of the sections.
+You will stand up a cluster as part of the workshop, but we won't be getting into the administration, network
+configuration or day-2 operations of Kubernetes itself. This is squarely a developer's workshop, so if you're after the
+low level or operational side of running Kubernetes clusters, this probably isn't the place for you.
+
+The app you'll be deploying is already written and built, so you won't need to write any application code yourself.
+
+Stuck on something? The [GitHub source repo for this workshop](https://github.com/benc-uk/kube-workshop) has example
+code and working files for every section.
 
 ## Azure Kubernetes Service (AKS)
 
-The main workshop has been built around using Azure Kubernetes Service (AKS) as the Kubernetes environment, almost none
-of the content is specific to AKS, and you can follow along with any Kubernetes cluster. However, if you want to follow
-along with the main content, you will need access to an Azure subscription to create the AKS cluster and other
-resources.
+The main workshop is built around Azure Kubernetes Service (AKS), but almost none of the content is actually specific to
+AKS, so you can happily follow along on any Kubernetes cluster. That said, to follow the main content as written you'll
+need access to an Azure subscription to spin up the AKS cluster and the other resources.
 
 Workshop sections & topics:
 

--- a/e2e-test/.gitignore
+++ b/e2e-test/.gitignore
@@ -1,0 +1,9 @@
+# Local working config (copy of vars.sh.sample) - keep your subscription id out of git
+vars.sh
+
+# Generated ACR name and rendered manifests
+.acr_name
+rendered/
+
+# Downloaded load-test binary (not used by default)
+hey_linux_amd64

--- a/e2e-test/00-preflight.sh
+++ b/e2e-test/00-preflight.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Section 0 - Preflight: verify tooling, Azure login and target subscription.
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+source ./vars.sh
+
+echo "==> Checking required tools"
+command -v az >/dev/null 2>&1 || { echo "ERROR: Azure CLI (az) not found. Install: https://aka.ms/azure-cli"; exit 1; }
+echo "  az      : $(az version --query '\"azure-cli\"' -o tsv 2>/dev/null || echo present)"
+
+if ! command -v kubectl >/dev/null 2>&1; then
+  echo "  kubectl : not found, installing via 'az aks install-cli'"
+  az aks install-cli
+fi
+echo "  kubectl : $(kubectl version --client -o yaml 2>/dev/null | grep -m1 gitVersion | awk '{print $2}' || echo present)"
+
+echo "==> Checking Azure login"
+if ! az account show >/dev/null 2>&1; then
+  echo "  Not logged in, launching 'az login'"
+  az login >/dev/null
+fi
+
+echo "==> Setting subscription"
+az account set --subscription "${SUBSCRIPTION_ID}"
+az account show -o table
+
+echo "==> Preflight complete"

--- a/e2e-test/01-aks.sh
+++ b/e2e-test/01-aks.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Section 1 - Deploy AKS cluster.
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+source ./vars.sh
+
+echo "==> Ensuring resource providers are registered"
+az provider register --namespace Microsoft.ContainerService >/dev/null 2>&1 || true
+
+echo "==> Creating resource group ${RES_GROUP} in ${REGION}"
+az group create --name "${RES_GROUP}" --location "${REGION}" -o table
+
+echo "==> Querying latest supported Kubernetes version in ${REGION}"
+KUBE_VERSION="$(az aks get-versions --location "${REGION}" -o json --query 'values[*].version | max(@)' -o tsv)"
+echo "  Using Kubernetes version: ${KUBE_VERSION}"
+
+if az aks show --resource-group "${RES_GROUP}" --name "${AKS_NAME}" >/dev/null 2>&1; then
+  echo "==> AKS cluster ${AKS_NAME} already exists, skipping create"
+else
+  echo "==> Creating AKS cluster ${AKS_NAME} (this takes ~5 min)"
+  if ! az aks create --resource-group "${RES_GROUP}" \
+      --name "${AKS_NAME}" \
+      --location "${REGION}" \
+      --node-count "${NODE_COUNT}" --node-vm-size "${NODE_VM_SIZE}" \
+      --kubernetes-version "${KUBE_VERSION}" \
+      --no-ssh-key; then
+    echo "==> Primary VM size ${NODE_VM_SIZE} failed, retrying with ${NODE_VM_SIZE_FALLBACK}"
+    az aks create --resource-group "${RES_GROUP}" \
+      --name "${AKS_NAME}" \
+      --location "${REGION}" \
+      --node-count "${NODE_COUNT}" --node-vm-size "${NODE_VM_SIZE_FALLBACK}" \
+      --kubernetes-version "${KUBE_VERSION}" \
+      --no-ssh-key
+  fi
+fi
+
+echo "==> Fetching cluster credentials"
+az aks get-credentials --name "${AKS_NAME}" --resource-group "${RES_GROUP}" --overwrite-existing
+
+echo "==> Cluster nodes"
+kubectl get nodes
+echo "==> Section 1 complete"

--- a/e2e-test/02-acr.sh
+++ b/e2e-test/02-acr.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Section 2 - Container registry: create ACR, import images, attach to AKS.
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+source ./vars.sh
+
+echo "==> Ensuring resource provider is registered"
+az provider register --namespace Microsoft.ContainerRegistry >/dev/null 2>&1 || true
+
+if az acr show --name "${ACR_NAME}" >/dev/null 2>&1; then
+  echo "==> ACR ${ACR_NAME} already exists, skipping create"
+else
+  echo "==> Creating ACR ${ACR_NAME}"
+  az acr create --name "${ACR_NAME}" --resource-group "${RES_GROUP}" --sku Standard -o table
+fi
+
+echo "==> Importing application images"
+images=(
+  "nanomon-frontend"
+  "nanomon-api"
+  "nanomon-runner"
+  "nanomon-postgres"
+)
+for img in "${images[@]}"; do
+  if az acr repository show --name "${ACR_NAME}" --image "${img}:latest" >/dev/null 2>&1; then
+    echo "  ${img}: already present, skipping"
+  else
+    echo "  ${img}: importing"
+    az acr import --name "${ACR_NAME}" --resource-group "${RES_GROUP}" \
+      --source "ghcr.io/benc-uk/${img}:latest" \
+      --image "${img}:latest"
+  fi
+done
+
+echo "==> Imported repositories:"
+az acr repository list --name "${ACR_NAME}" -o table
+
+echo "==> Attaching ACR to AKS (assigns AcrPull role)"
+az aks update --name "${AKS_NAME}" --resource-group "${RES_GROUP}" --attach-acr "${ACR_NAME}" -o none
+echo "==> Section 2 complete"

--- a/e2e-test/04-deploy.sh
+++ b/e2e-test/04-deploy.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Section 4 - Deploy the backend: PostgreSQL then the API.
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+source ./vars.sh
+
+mkdir -p rendered
+
+echo "==> Rendering postgres-deployment.yaml (__ACR_NAME__ -> ${ACR_NAME})"
+sed "s/__ACR_NAME__/${ACR_NAME}/g" \
+  "${MANIFEST_SRC}/postgres-deployment.yaml" >rendered/postgres-deployment.yaml
+
+echo "==> Applying PostgreSQL deployment"
+kubectl apply -f rendered/postgres-deployment.yaml
+
+echo "==> Waiting for PostgreSQL pod to be Ready"
+kubectl wait --for=condition=Ready pod --selector app=postgres --timeout=180s
+
+echo "==> Getting PostgreSQL pod IP"
+POSTGRES_POD_IP="$(kubectl get pod --selector app=postgres -o jsonpath='{.items[0].status.podIP}')"
+echo "  POSTGRES_POD_IP = ${POSTGRES_POD_IP}"
+if [[ -z "${POSTGRES_POD_IP}" ]]; then
+  echo "ERROR: could not determine postgres pod IP"; exit 1
+fi
+
+echo "==> Rendering api-deployment.yaml (__ACR_NAME__, __POSTGRES_POD_IP__, add port=5432)"
+sed -e "s/__ACR_NAME__/${ACR_NAME}/g" \
+    -e "s/__POSTGRES_POD_IP__/${POSTGRES_POD_IP}/g" \
+    -e "s/host=${POSTGRES_POD_IP} user=/host=${POSTGRES_POD_IP} port=5432 user=/g" \
+    "${MANIFEST_SRC}/api-deployment.yaml" >rendered/api-deployment.yaml
+
+echo "==> Applying API deployment"
+kubectl apply -f rendered/api-deployment.yaml
+
+echo "==> Waiting for API pods to be Ready"
+kubectl wait --for=condition=Ready pod --selector app=nanomon-api --timeout=180s
+
+echo "==> Current state"
+kubectl get deploy,pod -o wide
+
+echo "==> Smoke-testing the API via port-forward"
+API_POD="$(kubectl get pod --selector app=nanomon-api -o jsonpath='{.items[0].metadata.name}')"
+kubectl port-forward "${API_POD}" 8000:8000 >/tmp/ws1-pf.log 2>&1 &
+PF_PID=$!
+# give the tunnel a moment to establish
+for i in {1..10}; do
+  sleep 1
+  if curl -fsS http://localhost:8000/api/info >/dev/null 2>&1; then break; fi
+done
+echo "  /api/info:"
+curl -fsS http://localhost:8000/api/info || echo "  (info endpoint not reachable)"
+echo
+echo "  /api/status:"
+curl -fsS http://localhost:8000/api/status || echo "  (status endpoint not reachable)"
+echo
+kill "${PF_PID}" >/dev/null 2>&1 || true
+
+echo "==> Section 4 complete"

--- a/e2e-test/05-network.sh
+++ b/e2e-test/05-network.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Section 5 - Basic networking: Services for PostgreSQL and the API.
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+source ./vars.sh
+mkdir -p rendered
+SRC="${REPO_ROOT}/content/05-network-basics"
+
+echo "==> Applying PostgreSQL ClusterIP service (name: database)"
+kubectl apply -f "${SRC}/postgres-service.yaml"
+
+echo "==> Rendering & applying API deployment (DSN now targets host=database)"
+sed "s/__ACR_NAME__/${ACR_NAME}/g" "${SRC}/api-deployment.yaml" >rendered/05-api-deployment.yaml
+kubectl apply -f rendered/05-api-deployment.yaml
+
+echo "==> Applying API LoadBalancer service"
+kubectl apply -f "${SRC}/api-service.yaml"
+
+echo "==> Waiting for API rollout"
+kubectl rollout status deployment/nanomon-api --timeout=180s
+
+echo "==> Waiting for API service external IP (can take a couple of minutes)"
+API_IP=""
+for _ in $(seq 1 60); do
+  API_IP="$(kubectl get svc api -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null || true)"
+  [[ -n "${API_IP}" ]] && break
+  sleep 5
+done
+echo "  API external IP: ${API_IP:-<none>}"
+[[ -z "${API_IP}" ]] && { echo "ERROR: API external IP not assigned"; exit 1; }
+
+echo "==> Testing http://${API_IP}/api/status"
+curl -fsS --max-time 20 "http://${API_IP}/api/status" || echo "  (not reachable yet, may need a few more seconds)"
+echo
+echo "==> Section 5 complete"

--- a/e2e-test/06-frontend.sh
+++ b/e2e-test/06-frontend.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Section 6 - Add the frontend (Deployment + LoadBalancer Service).
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+source ./vars.sh
+mkdir -p rendered
+SRC="${REPO_ROOT}/content/06-frontend"
+
+echo "==> Resolving API external IP from 'api' service"
+API_IP="$(kubectl get svc api -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null || true)"
+[[ -z "${API_IP}" ]] && { echo "ERROR: API external IP not found, run 05-network.sh first"; exit 1; }
+echo "  API external IP: ${API_IP}"
+
+echo "==> Rendering & applying frontend deployment (__ACR_NAME__, __API_EXTERNAL_IP__)"
+sed -e "s/__ACR_NAME__/${ACR_NAME}/g" \
+    -e "s/__API_EXTERNAL_IP__/${API_IP}/g" \
+    "${SRC}/frontend-deployment.yaml" >rendered/06-frontend-deployment.yaml
+kubectl apply -f rendered/06-frontend-deployment.yaml
+
+echo "==> Applying frontend LoadBalancer service"
+kubectl apply -f "${SRC}/frontend-service.yaml"
+
+echo "==> Waiting for frontend rollout"
+kubectl rollout status deployment/nanomon-frontend --timeout=180s
+
+echo "==> Waiting for frontend service external IP"
+FE_IP=""
+for _ in $(seq 1 60); do
+  FE_IP="$(kubectl get svc frontend -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null || true)"
+  [[ -n "${FE_IP}" ]] && break
+  sleep 5
+done
+echo "  Frontend external IP: ${FE_IP:-<none>}"
+[[ -z "${FE_IP}" ]] && { echo "ERROR: frontend external IP not assigned"; exit 1; }
+
+echo "==> Testing http://${FE_IP}/"
+curl -fsS --max-time 20 -o /dev/null -w "  HTTP %{http_code}\n" "http://${FE_IP}/" || echo "  (not reachable yet)"
+echo "==> Frontend available at: http://${FE_IP}/"
+echo "==> Section 6 complete"

--- a/e2e-test/07-improvements.sh
+++ b/e2e-test/07-improvements.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Section 7 - Production readiness: resource limits, readiness probes, Secret.
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+source ./vars.sh
+mkdir -p rendered
+SRC="${REPO_ROOT}/content/07-improvements"
+
+echo "==> Creating/updating database-creds secret (idempotent)"
+kubectl create secret generic database-creds \
+  --from-literal password='kindaSecret123!' \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+echo "==> Resolving API external IP (needed by the frontend manifest)"
+API_IP="$(kubectl get svc api -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null || true)"
+[[ -z "${API_IP}" ]] && { echo "ERROR: API external IP not found, run earlier sections first"; exit 1; }
+echo "  API external IP: ${API_IP}"
+
+echo "==> Rendering improved manifests (resources, probes, secretKeyRef)"
+sed "s/__ACR_NAME__/${ACR_NAME}/g" "${SRC}/postgres-deployment.yaml" >rendered/07-postgres-deployment.yaml
+sed "s/__ACR_NAME__/${ACR_NAME}/g" "${SRC}/api-deployment.yaml" >rendered/07-api-deployment.yaml
+sed -e "s/__ACR_NAME__/${ACR_NAME}/g" -e "s/__API_EXTERNAL_IP__/${API_IP}/g" \
+    "${SRC}/frontend-deployment.yaml" >rendered/07-frontend-deployment.yaml
+
+echo "==> Applying improved deployments"
+kubectl apply -f rendered/07-postgres-deployment.yaml
+kubectl apply -f rendered/07-api-deployment.yaml
+kubectl apply -f rendered/07-frontend-deployment.yaml
+
+echo "==> Waiting for rollouts"
+kubectl rollout status deployment/postgres --timeout=180s
+kubectl rollout status deployment/nanomon-api --timeout=180s
+kubectl rollout status deployment/nanomon-frontend --timeout=180s
+
+echo "==> Final state"
+kubectl get deploy,svc,secret
+
+echo "==> Verifying API health via external IP"
+curl -fsS --max-time 20 "http://${API_IP}/api/status" && echo
+echo "==> Section 7 complete"

--- a/e2e-test/08-more-improvements.sh
+++ b/e2e-test/08-more-improvements.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Section 8 - ConfigMaps & Volumes: official postgres image + init SQL, plus the runner.
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+source ./vars.sh
+mkdir -p rendered
+SRC="${REPO_ROOT}/content/08-more-improvements"
+
+echo "==> Creating/updating nanomon-sql-init ConfigMap from nanomon_init.sql"
+kubectl create configmap nanomon-sql-init \
+  --from-file="${SRC}/nanomon_init.sql" \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+echo "==> Recreating postgres deployment (official postgres:17 + initdb volume)"
+# Delete first so the new official image initialises a fresh data dir and runs the init script.
+kubectl delete deployment postgres --ignore-not-found
+kubectl apply -f "${SRC}/postgres-deployment.yaml"
+kubectl rollout status deployment/postgres --timeout=180s
+
+echo "==> Postgres init log (should show nanomon_init.sql executed)"
+kubectl logs -l app=postgres --tail=40 | grep -Ei 'nanomon_init|database system is ready|CREATE' || true
+
+echo "==> Rendering & applying the runner deployment"
+sed "s/__ACR_NAME__/${ACR_NAME}/g" "${SRC}/runner-deployment.yaml" >rendered/08-runner-deployment.yaml
+kubectl apply -f rendered/08-runner-deployment.yaml
+kubectl rollout status deployment/nanomon-runner --timeout=180s
+
+echo "==> Current state"
+kubectl get deploy,pod,configmap
+
+echo "==> Runner log (last few lines)"
+kubectl logs -l app=nanomon-runner --tail=15 || true
+echo "==> Section 8 complete"

--- a/e2e-test/09a-gateway.sh
+++ b/e2e-test/09a-gateway.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Section 9a - Helm & Gateway API: NGINX Gateway Fabric, Gateway + HTTPRoute.
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+source ./vars.sh
+mkdir -p rendered
+SRC="${REPO_ROOT}/content/09a-helm-gateway-api"
+GW_API_VERSION="v1.4.1"
+
+echo "==> Installing Gateway API CRDs (${GW_API_VERSION}, standard channel)"
+kubectl apply --server-side -f \
+  "https://github.com/kubernetes-sigs/gateway-api/releases/download/${GW_API_VERSION}/standard-install.yaml"
+
+echo "==> Ensuring 'nginx-gateway' namespace exists"
+kubectl create namespace nginx-gateway --dry-run=client -o yaml | kubectl apply -f -
+
+echo "==> Installing/upgrading NGINX Gateway Fabric (helm release ngf)"
+helm upgrade --install ngf oci://ghcr.io/nginx/charts/nginx-gateway-fabric \
+  --namespace nginx-gateway --wait --timeout 5m
+
+echo "==> Applying the Gateway resource (in nginx-gateway namespace)"
+kubectl apply -f "${SRC}/gateway.yaml" -n nginx-gateway
+
+echo "==> Waiting for gateway service external IP"
+GW_IP=""
+for _ in $(seq 1 60); do
+  GW_IP="$(kubectl get svc nanomon-gateway-nginx -n nginx-gateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null || true)"
+  [[ -n "${GW_IP}" ]] && break
+  sleep 5
+done
+echo "  Gateway external IP: ${GW_IP:-<none>}"
+[[ -z "${GW_IP}" ]] && { echo "ERROR: gateway external IP not assigned"; exit 1; }
+
+echo "==> Switching API & frontend services to ClusterIP on container ports (8000 / 8001)"
+kubectl apply -f "${SRC}/api-service.yaml"
+kubectl apply -f "${SRC}/frontend-service.yaml"
+
+echo "==> Ensuring frontend uses same-origin /api"
+sed "s/__ACR_NAME__/${ACR_NAME}/g" "${SRC}/frontend-deployment.yaml" >rendered/09a-frontend-deployment.yaml
+kubectl apply -f rendered/09a-frontend-deployment.yaml
+kubectl rollout status deployment/nanomon-frontend --timeout=180s
+
+echo "==> Applying the HTTPRoute"
+kubectl apply -f "${SRC}/http-route.yaml"
+
+echo "==> Final state"
+kubectl get gateway,httproute
+echo "--- gateway namespace services ---"
+kubectl get svc -n nginx-gateway
+echo "--- app services ---"
+kubectl get svc
+
+echo "==> Testing through the gateway IP ${GW_IP}"
+sleep 5
+curl -fsS --max-time 20 -o /dev/null -w "  GET /  -> HTTP %{http_code}\n" "http://${GW_IP}/" || echo "  (frontend not reachable yet)"
+echo "==> Section 9a complete - app served at http://${GW_IP}/"

--- a/e2e-test/10-scaling-stateful.sh
+++ b/e2e-test/10-scaling-stateful.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Section 10 - Scaling & Stateful workloads: manual scale, HPA, postgres StatefulSet + PVC.
+# Skips the destructive "delete everything + helm install whole app" step (it uses Ingress,
+# and we deliberately moved to the Gateway API in 9a).
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+source ./vars.sh
+SRC="${REPO_ROOT}/content/10-extra-advanced"
+
+echo "############################################################"
+echo "# 1. Manual horizontal scaling of the API"
+echo "############################################################"
+kubectl scale deployment nanomon-api --replicas 4
+kubectl rollout status deployment/nanomon-api --timeout=120s
+kubectl get pods -l app=nanomon-api -o wide
+echo "==> Scaling back to 2"
+kubectl scale deployment nanomon-api --replicas 2
+
+echo
+echo "############################################################"
+echo "# 2. Convert postgres Deployment -> StatefulSet with a PVC"
+echo "############################################################"
+echo "==> Deleting the postgres Deployment (data is ephemeral until now)"
+kubectl delete deployment postgres --ignore-not-found
+echo "==> Applying the StatefulSet (dynamic PVC on 'default' storage class)"
+kubectl apply -f "${SRC}/postgres-statefulset.yaml"
+echo "==> Waiting for postgres-0 to be Ready (PVC provisioning can take a minute)"
+kubectl rollout status statefulset/postgres --timeout=300s
+echo "==> PersistentVolume / PersistentVolumeClaim:"
+kubectl get pv,pvc
+echo "==> postgres init log (init script runs once on the fresh volume):"
+kubectl logs -l app=postgres --tail=15 | grep -Ei 'nanomon_init|ready to accept' || true
+
+echo
+echo "############################################################"
+echo "# 3. Horizontal Pod Autoscaler for the API"
+echo "############################################################"
+kubectl delete hpa nanomon-api --ignore-not-found
+kubectl autoscale deployment nanomon-api --cpu-percent=50 --min=2 --max=10
+kubectl get hpa nanomon-api
+
+echo
+echo "############################################################"
+echo "# 4. (Best effort) generate load and watch the HPA react"
+echo "############################################################"
+GW_IP="$(kubectl get svc nanomon-gateway-nginx -n nginx-gateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null || true)"
+if [[ -z "${GW_IP}" ]]; then
+  echo "  No gateway IP found, skipping load test."
+else
+  if [[ ! -x ./hey_linux_amd64 ]]; then
+    echo "==> Downloading 'hey' load generator"
+    wget -q https://hey-release.s3.us-east-2.amazonaws.com/hey_linux_amd64 -O hey_linux_amd64 && chmod +x hey_linux_amd64 || echo "  (download failed)"
+  fi
+  if [[ -x ./hey_linux_amd64 ]]; then
+    echo "==> Generating load for 120s against http://${GW_IP}/api/status (20 concurrent)"
+    ./hey_linux_amd64 -z 120s -c 20 "http://${GW_IP}/api/status" >/dev/null 2>&1 || true
+    echo "==> HPA status after load:"
+    kubectl get hpa nanomon-api
+    kubectl get pods -l app=nanomon-api
+    echo "  (Pods scale back to min=2 ~5 min after load stops.)"
+  fi
+fi
+
+echo
+echo "==> Section 10 complete (skipped destructive whole-app Helm reinstall by design)"

--- a/e2e-test/11-observability.sh
+++ b/e2e-test/11-observability.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Section 11 - Observability: install kube-prometheus-stack and verify Prometheus + Grafana.
+# The dashboard exploration is browser-only; here we prove the stack works via API calls.
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+source ./vars.sh
+
+echo "==> Adding/updating the prometheus-community Helm repo"
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts >/dev/null 2>&1 || true
+helm repo update prometheus-community >/dev/null
+
+echo "==> Ensuring 'monitoring' namespace exists"
+kubectl create namespace monitoring --dry-run=client -o yaml | kubectl apply -f -
+
+echo "==> Installing/upgrading kube-prometheus-stack (release kube-mon)"
+helm upgrade --install kube-mon prometheus-community/kube-prometheus-stack \
+  --namespace monitoring \
+  --set grafana.adminPassword=workshopAdmin \
+  --set prometheus.prometheusSpec.podMonitorSelectorNilUsesHelmValues=false \
+  --set prometheus.prometheusSpec.serviceMonitorSelectorNilUsesHelmValues=false \
+  --wait --timeout 10m
+
+echo "==> Waiting for the operator-created Prometheus & Alertmanager pods"
+kubectl wait --for=condition=Ready pod -l app.kubernetes.io/name=prometheus -n monitoring --timeout=300s || true
+kubectl wait --for=condition=Ready pod -l app.kubernetes.io/name=alertmanager -n monitoring --timeout=300s || true
+
+echo "==> Monitoring stack pods:"
+kubectl get pods -n monitoring
+
+# Resolve service names dynamically (release-name prefix is truncated in the chart)
+PROM_SVC="$(kubectl get svc -n monitoring --no-headers -o custom-columns=:.metadata.name | grep -E 'prometheus$' | grep -v operator | head -1)"
+GRAF_SVC="$(kubectl get svc -n monitoring --no-headers -o custom-columns=:.metadata.name | grep -E 'grafana$' | head -1)"
+echo "  Prometheus service: ${PROM_SVC}"
+echo "  Grafana service:    ${GRAF_SVC}"
+
+echo "==> Verifying Prometheus via a PromQL query (running pods per namespace)"
+kubectl port-forward -n monitoring "svc/${PROM_SVC}" 9090:9090 >/tmp/ws1-prom-pf.log 2>&1 &
+PF_PROM=$!
+sleep 5
+curl -fsS --max-time 15 --data-urlencode 'query=count by (namespace) (kube_pod_status_phase{phase="Running"})' \
+  http://localhost:9090/api/v1/query | head -c 600 || echo "  (prometheus query failed)"
+echo
+kill "${PF_PROM}" >/dev/null 2>&1 || true
+
+echo "==> Verifying Grafana health endpoint"
+kubectl port-forward -n monitoring "svc/${GRAF_SVC}" 3000:80 >/tmp/ws1-graf-pf.log 2>&1 &
+PF_GRAF=$!
+sleep 5
+curl -fsS --max-time 15 http://localhost:3000/api/health || echo "  (grafana health failed)"
+echo
+kill "${PF_GRAF}" >/dev/null 2>&1 || true
+
+echo "==> Section 11 complete"
+echo "  Grafana login: admin / workshopAdmin (port-forward svc/${GRAF_SVC} 3000:80)"
+echo "  Prometheus UI: port-forward svc/${PROM_SVC} 9090:9090"

--- a/e2e-test/90-teardown.sh
+++ b/e2e-test/90-teardown.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Teardown - delete the Azure resource group created by this e2e test.
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+source ./vars.sh
+
+echo "This will DELETE resource group '${RES_GROUP}' (subscription ${SUBSCRIPTION_ID}) and EVERYTHING in it."
+if [[ "${1:-}" != "--yes" ]]; then
+  echo
+  echo "Dry run. Re-run with --yes to actually delete:"
+  echo "  ./90-teardown.sh --yes"
+  exit 0
+fi
+
+az account set --subscription "${SUBSCRIPTION_ID}"
+echo "==> Deleting resource group ${RES_GROUP} (async, returns immediately)"
+az group delete --name "${RES_GROUP}" --yes --no-wait
+echo "==> Delete initiated."
+echo "    Local state (.acr_name, rendered/) left intact; delete them for a fresh ACR name next run."

--- a/e2e-test/README.md
+++ b/e2e-test/README.md
@@ -1,0 +1,109 @@
+# Kube Workshop - End-to-End Test
+
+Automated, scripted run-through of the [kube-workshop](../readme.md) against a real Azure
+Kubernetes Service (AKS) cluster. It stands up everything the workshop builds by hand, sections 0
+through 9a, and includes the optional bonus sections 10 and 11.
+
+The scripts render the workshop's own YAML manifests from `../content/**` (substituting the
+`__PLACEHOLDER__` values) and apply them, so this doubles as a smoke test that the workshop
+instructions still work end to end.
+
+## What it deploys
+
+The full NanoMon app on AKS: PostgreSQL, the data API, the frontend and the runner, fronted by the
+Kubernetes Gateway API (NGINX Gateway Fabric). Everything lands in one Azure resource group.
+
+## Prerequisites
+
+- `az` (Azure CLI), logged in to a subscription where you have **Owner** (needed to attach ACR to AKS)
+- `kubectl` and `helm`
+- `bash`, `curl`, `openssl`
+- `wget`/`curl` outbound access for Helm charts and container images
+
+## Setup
+
+```bash
+cp vars.sh.sample vars.sh   # then edit vars.sh (or override values via the environment)
+```
+
+`vars.sh` is git-ignored, so your subscription id and names never get committed. Key settings:
+
+| Variable          | Default              | Notes                                                 |
+| ----------------- | -------------------- | ----------------------------------------------------- |
+| `SUBSCRIPTION_ID` | current `az` context | Subscription to deploy into                           |
+| `RES_GROUP`       | `kube-workshop-e2e`  | Resource group (created if missing)                   |
+| `REGION`          | `northeurope`        | Azure region                                          |
+| `AKS_NAME`        | `aks-kube-workshop`  | Cluster name                                          |
+| `ACR_NAME`        | auto-generated       | Globally unique, persisted to `.acr_name`             |
+| `NODE_VM_SIZE`    | `Standard_B2ms`      | Falls back to `NODE_VM_SIZE_FALLBACK` on quota errors |
+
+## Usage
+
+Run the whole main workshop (sections 0 to 9a):
+
+```bash
+./run-all.sh
+```
+
+Or run any step on its own (each is idempotent and re-runnable):
+
+```bash
+source vars.sh
+./00-preflight.sh
+./01-aks.sh
+...
+```
+
+When it finishes, `09a-gateway.sh` prints the single public IP the app is served on
+(`http://<gateway-ip>/`).
+
+## Scripts
+
+| Script                    | Workshop section | What it does                                                  |
+| ------------------------- | ---------------- | ------------------------------------------------------------- |
+| `vars.sh`                 | 0                | Shared config (copied from `vars.sh.sample`)                  |
+| `00-preflight.sh`         | 0                | Checks tools, `az login`, sets the subscription               |
+| `01-aks.sh`               | 1                | Resource group + AKS cluster (auto-picks latest k8s version)  |
+| `02-acr.sh`               | 2                | ACR, imports the 4 NanoMon images, attaches ACR to AKS        |
+| `04-deploy.sh`            | 4                | Deploys PostgreSQL + API                                      |
+| `05-network.sh`           | 5                | `database` service, exposes the API via LoadBalancer          |
+| `06-frontend.sh`          | 6                | Deploys + exposes the frontend                                |
+| `07-improvements.sh`      | 7                | Resource limits, readiness probes, DB password Secret         |
+| `08-more-improvements.sh` | 8                | SQL init ConfigMap, official `postgres:17`, the runner        |
+| `09a-gateway.sh`          | 9a               | Gateway API CRDs + NGINX Gateway Fabric, Gateway + HTTPRoute  |
+| `run-all.sh`              | 0-9a             | Runs the above in order, stops on first failure               |
+| `10-scaling-stateful.sh`  | 10 (bonus)       | Manual scaling, HPA, postgres StatefulSet + PVC               |
+| `hpa-loadtest.sh`         | 10 (bonus)       | Parallel-curl load generator to exercise the HPA              |
+| `11-observability.sh`     | 11 (bonus)       | Installs kube-prometheus-stack, verifies Prometheus + Grafana |
+| `90-teardown.sh`          | -                | Deletes the resource group (`--yes` to confirm)               |
+
+> Section 3 is overview-only (no tasks). Section 9 (legacy NGINX Ingress) is intentionally not
+> included; this harness uses the newer Gateway API (9a) instead. The bonus scripts (10, 11) are
+> not part of `run-all.sh` because they are optional and resource-heavy.
+
+## Notes & gotchas
+
+- **Rendered manifests** are written to `rendered/` (git-ignored). The repo's source manifests under
+  `../content/**` are never modified.
+- **Idempotent**: every script can be re-run safely. The ACR name is generated once and pinned in
+  `.acr_name`.
+- **Bonus section 10** uses a parallel-`curl` load generator (`hpa-loadtest.sh`) because the upstream
+  `hey` binary download is currently blocked.
+- **Bonus section 11** adds real load to a small cluster. Access Grafana with
+  `kubectl port-forward -n monitoring svc/kube-mon-grafana 3000:80` (login `admin` / `workshopAdmin`).
+- **Long-running commands** (e.g. the Helm installs) are best run to completion; they can take a few
+  minutes.
+
+## Teardown
+
+```bash
+./90-teardown.sh          # dry run, shows what would be deleted
+./90-teardown.sh --yes    # actually delete the resource group
+```
+
+To pause instead of delete (keeps the cluster but stops the node VMs to cut cost):
+
+```bash
+az aks stop  --resource-group "$RES_GROUP" --name "$AKS_NAME"
+az aks start --resource-group "$RES_GROUP" --name "$AKS_NAME"
+```

--- a/e2e-test/hpa-loadtest.sh
+++ b/e2e-test/hpa-loadtest.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Best-effort HPA load test using parallel curl (hey binary download is blocked).
+set -uo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+source ./vars.sh >/dev/null
+
+GW_IP="$(kubectl get svc nanomon-gateway-nginx -n nginx-gateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null || true)"
+[[ -z "${GW_IP}" ]] && { echo "No gateway IP, aborting"; exit 1; }
+
+DURATION="${1:-150}"
+WORKERS="${2:-40}"
+echo "==> HPA before load:"
+kubectl get hpa nanomon-api
+
+echo "==> Generating load: ${WORKERS} workers x ${DURATION}s against http://${GW_IP}/api/status"
+end=$((SECONDS + DURATION))
+for _ in $(seq 1 "${WORKERS}"); do
+  ( while [ "${SECONDS}" -lt "${end}" ]; do curl -s -o /dev/null --max-time 5 "http://${GW_IP}/api/status"; done ) &
+done
+wait
+
+echo "==> HPA after load:"
+kubectl get hpa nanomon-api
+echo "==> API pods after load:"
+kubectl get pods -l app=nanomon-api
+echo "  (HPA scales back to min=2 a few minutes after load stops.)"

--- a/e2e-test/run-all.sh
+++ b/e2e-test/run-all.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Run the full chain: preflight -> AKS -> ACR -> backend (sections 0,1,2,4).
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+./00-preflight.sh
+./01-aks.sh
+./02-acr.sh
+./04-deploy.sh
+./05-network.sh
+./06-frontend.sh
+./07-improvements.sh
+./08-more-improvements.sh
+./09a-gateway.sh
+
+echo
+echo "==================================================="
+echo " All sections (0-8 + 9a Gateway API) completed."
+echo "==================================================="

--- a/e2e-test/vars.sh.sample
+++ b/e2e-test/vars.sh.sample
@@ -1,0 +1,35 @@
+# Copy this file to vars.sh and adjust, then `source vars.sh`:
+#     cp vars.sh.sample vars.sh
+# Every value can also be overridden from the environment, e.g.  REGION=uksouth ./run-all.sh
+#
+# NOTE: vars.sh is git-ignored (matches the repo's `vars*.sh` rule) so your real
+# subscription id and names never get committed.
+
+# Azure subscription to deploy into. Defaults to your current `az` context.
+export SUBSCRIPTION_ID="${SUBSCRIPTION_ID:-$(az account show --query id -o tsv 2>/dev/null)}"
+
+export RES_GROUP="${RES_GROUP:-kube-workshop-e2e}"
+export REGION="${REGION:-northeurope}"
+export AKS_NAME="${AKS_NAME:-aks-kube-workshop}"
+export NODE_COUNT="${NODE_COUNT:-2}"
+export NODE_VM_SIZE="${NODE_VM_SIZE:-Standard_B2ms}"
+# Fallback node size used automatically if the primary size has no quota
+export NODE_VM_SIZE_FALLBACK="${NODE_VM_SIZE_FALLBACK:-Standard_D4ds_v5}"
+
+# ACR name must be globally unique, lowercase, alphanumeric only (no hyphens/dots).
+# Generated once and persisted to .acr_name so it stays stable across reruns.
+# Set ACR_NAME in the environment to pin a specific name.
+_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_ACR_NAME_FILE="${_SCRIPT_DIR}/.acr_name"
+if [[ -n "${ACR_NAME:-}" ]]; then
+  echo "${ACR_NAME}" >"${_ACR_NAME_FILE}"
+elif [[ ! -f "${_ACR_NAME_FILE}" ]]; then
+  echo "acrkw$(openssl rand -hex 4)" >"${_ACR_NAME_FILE}"
+fi
+export ACR_NAME="$(cat "${_ACR_NAME_FILE}")"
+
+# Location of the repo's source manifests (templates with __PLACEHOLDERS__)
+export REPO_ROOT="$(cd "${_SCRIPT_DIR}/.." && pwd)"
+export MANIFEST_SRC="${REPO_ROOT}/content/04-deployment"
+
+echo "Loaded vars: RG=${RES_GROUP} REGION=${REGION} AKS=${AKS_NAME} ACR=${ACR_NAME}"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,20 @@
 {
   "name": "kube-workshop",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kube-workshop",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
-        "@11ty/eleventy": "^3.1.2",
+        "@11ty/eleventy": "^3.1.6",
         "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.2",
         "clean-css": "^5.3.3",
-        "markdown-it": "^14.1.1",
-        "markdown-it-attrs": "^4.3.1",
-        "prettier": "^3.8.1"
+        "markdown-it": "^14.2.0",
+        "markdown-it-attrs": "^5.0.0",
+        "prettier": "^3.8.4"
       }
     },
     "node_modules/@11ty/dependency-tree": {
@@ -39,44 +39,44 @@
       }
     },
     "node_modules/@11ty/eleventy": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@11ty/eleventy/-/eleventy-3.1.2.tgz",
-      "integrity": "sha512-IcsDlbXnBf8cHzbM1YBv3JcTyLB35EK88QexmVyFdVJVgUU6bh9g687rpxryJirHzo06PuwnYaEEdVZQfIgRGg==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@11ty/eleventy/-/eleventy-3.1.6.tgz",
+      "integrity": "sha512-ZlSiR1PLdS2lv7TelBgWAhcvMiLNZkPBlLEb+lh7kGYZ+Mk0bo9qcYgVsewvw9W7Em0RH3wd01h5fAstNDh0zA==",
       "license": "MIT",
       "dependencies": {
-        "@11ty/dependency-tree": "^4.0.0",
-        "@11ty/dependency-tree-esm": "^2.0.0",
+        "@11ty/dependency-tree": "^4.0.2",
+        "@11ty/dependency-tree-esm": "^2.0.4",
         "@11ty/eleventy-dev-server": "^2.0.8",
-        "@11ty/eleventy-plugin-bundle": "^3.0.6",
+        "@11ty/eleventy-plugin-bundle": "^3.0.7",
         "@11ty/eleventy-utils": "^2.0.7",
         "@11ty/lodash-custom": "^4.17.21",
-        "@11ty/posthtml-urls": "^1.0.1",
-        "@11ty/recursive-copy": "^4.0.2",
+        "@11ty/posthtml-urls": "^1.0.3",
+        "@11ty/recursive-copy": "^4.0.4",
         "@sindresorhus/slugify": "^2.2.1",
         "bcp-47-normalize": "^2.3.0",
         "chokidar": "^3.6.0",
-        "debug": "^4.4.1",
+        "debug": "^4.4.3",
         "dependency-graph": "^1.0.0",
         "entities": "^6.0.1",
         "filesize": "^10.1.6",
         "gray-matter": "^4.0.3",
         "iso-639-1": "^3.1.5",
-        "js-yaml": "^4.1.0",
+        "js-yaml": "^4.1.1",
         "kleur": "^4.1.5",
-        "liquidjs": "^10.21.1",
-        "luxon": "^3.6.1",
-        "markdown-it": "^14.1.0",
+        "liquidjs": "^10.27.0",
+        "luxon": "^3.7.2",
+        "markdown-it": "^14.2.0",
         "minimist": "^1.2.8",
-        "moo": "^0.5.2",
+        "moo": "0.5.2",
         "node-retrieve-globals": "^6.0.1",
         "nunjucks": "^3.2.4",
-        "picomatch": "^4.0.2",
+        "picomatch": "^4.0.4",
         "please-upgrade-node": "^3.2.0",
-        "posthtml": "^0.16.6",
+        "posthtml": "^0.16.7",
         "posthtml-match-helper": "^2.0.3",
-        "semver": "^7.7.2",
-        "slugify": "^1.6.6",
-        "tinyglobby": "^0.2.14"
+        "semver": "^7.8.1",
+        "slugify": "^1.6.9",
+        "tinyglobby": "^0.2.16"
       },
       "bin": {
         "eleventy": "cmd.cjs"
@@ -177,9 +177,9 @@
       }
     },
     "node_modules/@11ty/posthtml-urls": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@11ty/posthtml-urls/-/posthtml-urls-1.0.2.tgz",
-      "integrity": "sha512-0vaV3Wt0surZ+oS1VdKKe0axeeupuM+l7W/Z866WFQwF+dGg2Tc/nmhk/5l74/Y55P8KyImnLN9CdygNw2huHg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@11ty/posthtml-urls/-/posthtml-urls-1.0.3.tgz",
+      "integrity": "sha512-1YvhnkaNlFnnJic1rBMWmTC2adbuy+JQiBfl1Hecr1Wjjik1pQZmGyk/eC9zKX/FQv52s2Nht1Gi/UwhYqrBeg==",
       "license": "MIT",
       "dependencies": {
         "evaluate-value": "^2.0.0",
@@ -192,14 +192,14 @@
       }
     },
     "node_modules/@11ty/recursive-copy": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@11ty/recursive-copy/-/recursive-copy-4.0.3.tgz",
-      "integrity": "sha512-SX48BTLEGX8T/OsKWORsHAAeiDsbFl79Oa/0Wg/mv/d27b7trCVZs7fMHvpSgDvZz/fZqx5rDk8+nx5oyT7xBw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@11ty/recursive-copy/-/recursive-copy-4.0.4.tgz",
+      "integrity": "sha512-oI7m8pa7/IAU/3lqRU9vjBbs20iKFo7x+1K9kT3aVira6scc1X9MjBdgLCHzLJeJ7iB6wydioA+kr9/qPnvmlQ==",
       "license": "ISC",
       "dependencies": {
         "errno": "^1.0.0",
         "junk": "^3.1.0",
-        "maximatch": "^0.1.0",
+        "minimatch": "^3.1.5",
         "slash": "^3.0.0"
       },
       "engines": {
@@ -244,9 +244,9 @@
       "license": "MIT"
     },
     "node_modules/acorn": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -256,9 +256,9 @@
       }
     },
     "node_modules/acorn-walk": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
-      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.11.0"
@@ -281,9 +281,9 @@
       }
     },
     "node_modules/anymatch/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -297,45 +297,6 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
-    },
-    "node_modules/array-differ": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
-      "integrity": "sha512-LeZY+DZDRnvP7eMuQ6LHfCzUGxAAIViUBliK24P3hWXL6y4SortgR6Nim6xrkfSLlmH0+k+9NYNwVC2s53ZrYQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/array-union": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-      "integrity": "sha512-Dxr6QJj/RdU/hCaBjOfxW+q6lyuVE6JFWIrAUpuOOhoJJoQ99cUn3igRaHVB5P9WrgFVN0FfArM3x0cueOU8ng==",
-      "license": "MIT",
-      "dependencies": {
-        "array-uniq": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/array-uniq": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-      "integrity": "sha512-MNha4BWQ6JbwhFhj03YK552f7cb3AzoE8SzeljgChvL1dl3IcvggXVz1DilzySZkCja+CXuZbdW7yATchWn8/Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/arrify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/asap": {
       "version": "2.0.6",
@@ -401,9 +362,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -991,9 +952,19 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -1030,18 +1001,28 @@
       }
     },
     "node_modules/linkify-it": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
-      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
+      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "uc.micro": "^2.0.0"
       }
     },
     "node_modules/liquidjs": {
-      "version": "10.24.0",
-      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.24.0.tgz",
-      "integrity": "sha512-TAUNAdgwaAXjjcUFuYVJm9kOVH7zc0mTKxsG9t9Lu4qdWjB2BEblyVIYpjWcmJLMGgiYqnGNJjpNMHx0gp/46A==",
+      "version": "10.27.0",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.27.0.tgz",
+      "integrity": "sha512-tw/OA59K7aIBlMKIrKlumr37fiZUheShVHXY8cVctWisgY1p9mc5hreOvlreoS0wTiwlWk14Ya7305c2a/Cg5w==",
       "license": "MIT",
       "dependencies": {
         "commander": "^10.0.0"
@@ -1074,14 +1055,24 @@
       }
     },
     "node_modules/markdown-it": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
-      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.2.0.tgz",
+      "integrity": "sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1",
         "entities": "^4.4.0",
-        "linkify-it": "^5.0.0",
+        "linkify-it": "^5.0.1",
         "mdurl": "^2.0.0",
         "punycode.js": "^2.3.1",
         "uc.micro": "^2.1.0"
@@ -1091,9 +1082,9 @@
       }
     },
     "node_modules/markdown-it-attrs": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/markdown-it-attrs/-/markdown-it-attrs-4.3.1.tgz",
-      "integrity": "sha512-/ko6cba+H6gdZ0DOw7BbNMZtfuJTRp9g/IrGIuz8lYc/EfnmWRpaR3CFPnNbVz0LDvF8Gf1hFGPqrQqq7De0rg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-attrs/-/markdown-it-attrs-5.0.0.tgz",
+      "integrity": "sha512-7Wvp3Fc1YsHsj1oRKli1DGAMyGhozldtU99wEl4plc6OBsv1WZB+zT3Lgm1/49rVMvXWiYXbUU8rz3X6VVGKaQ==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -1112,21 +1103,6 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/maximatch": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/maximatch/-/maximatch-0.1.0.tgz",
-      "integrity": "sha512-9ORVtDUFk4u/NFfo0vG/ND/z7UQCVZBL539YW0+U1I7H1BkZwizcPx5foFv7LCPcBnm2U6RjFnQOsIvN4/Vm2A==",
-      "license": "MIT",
-      "dependencies": {
-        "array-differ": "^1.0.0",
-        "array-union": "^1.0.1",
-        "arrify": "^1.0.0",
-        "minimatch": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/mdurl": {
@@ -1173,9 +1149,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -1194,10 +1170,10 @@
       }
     },
     "node_modules/minipass": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-      "license": "ISC",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -1302,9 +1278,9 @@
       }
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -1372,9 +1348,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
-      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
+      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
       "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -1432,9 +1408,9 @@
       }
     },
     "node_modules/readdirp/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -1457,9 +1433,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -1516,9 +1492,9 @@
       }
     },
     "node_modules/slugify": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.6.tgz",
-      "integrity": "sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==",
+      "version": "1.6.9",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.9.tgz",
+      "integrity": "sha512-vZ7rfeehZui7wQs438JXBckYLkIIdfHOXsaVEUMyS5fHo1483l1bMdo0EDSWYclY0yZKFOipDy4KHuKs6ssvdg==",
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
@@ -1570,13 +1546,13 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -1628,9 +1604,9 @@
       "license": "MIT"
     },
     "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -13,11 +13,11 @@
     "clean": "rm -rf _site"
   },
   "dependencies": {
-    "@11ty/eleventy": "^3.1.2",
+    "@11ty/eleventy": "^3.1.6",
     "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.2",
     "clean-css": "^5.3.3",
-    "markdown-it": "^14.1.1",
-    "markdown-it-attrs": "^4.3.1",
-    "prettier": "^3.8.1"
+    "markdown-it": "^14.2.0",
+    "markdown-it-attrs": "^5.0.0",
+    "prettier": "^3.8.4"
   }
 }


### PR DESCRIPTION
Update GitHub Actions and dependencies to their latest versions, upgrade Kubernetes to 1.36, and add end-to-end test scripts along with improved workshop descriptions for better clarity.