### PR TITLE
Fix spelling and typos in workshop content

### DIFF
--- a/content/04-deployment/index.md
+++ b/content/04-deployment/index.md
@@ -190,7 +190,7 @@ _Pods_ have been scheduled (assigned) to. You might see each _Pod_ has been sche
 not guaranteed. _Pod_ scheduling and placement is a fairly complex topic, for now we can move on.
 
 It's also worth mention the _Pod_ names, they are prefixed with the name of the _Deployment_, followed by a hash,
-folowed by a random string. _Pod_ names are nearly always auto-generated like this, and are not something you should
+followed by a random string. _Pod_ names are nearly always auto-generated like this, and are not something you should
 rely on or try to set yourself.
 
 ## ⏩ Accessing the API (The quick & dirty way)

--- a/content/07-improvements/index.md
+++ b/content/07-improvements/index.md
@@ -124,7 +124,7 @@ kubectl create secret generic database-creds \
 --from-literal password='kindaSecret123!'
 ```
 
-A _Secrets_ resource can contain multiple keys, but here we add a single key one for the datbase user password called
+A _Secrets_ resource can contain multiple keys, but here we add a single key one for the database user password called
 `password`
 
 _Secrets_ can be used a number of ways, but the easiest way to consume them, is as environmental variables passed into
@@ -139,15 +139,15 @@ your containers. Update the deployment YAML for **BOTH your API, and PostgreSQL 
       key: password
 ```
 
-> _Secrets_ aren't quite as secret as they sound, they are not encypted and are simply stored as base-64 encoded values.
-> Gasp! They mainly keep any plain text values out of our manifests. Anyone with the relevant cluster priviledges will
-> be able to read the values of _Secrets_ easily. If you want further encryption and isolation a number of options are
-> available including Mozilla SOPS, Hashicorp Vault and Azure Key Vault.
+> _Secrets_ aren't quite as secret as they sound, they are not encrypted and are simply stored as base-64 encoded
+> values. Gasp! They mainly keep any plain text values out of our manifests. Anyone with the relevant cluster privileges
+> will be able to read the values of _Secrets_ easily. If you want further encryption and isolation a number of options
+> are available including Mozilla SOPS, Hashicorp Vault and Azure Key Vault.
 
 ## 🖼️ Cluster & Architecture Diagram
 
-Desptite the improvements we've made, the fundamental architecture of our deployment has not significantly changed
-beyond the addition of a _Secret_ resource, so we'll skip the diagram this time.
+Despite the improvements we've made, the fundamental architecture of our deployment has not significantly changed beyond
+the addition of a _Secret_ resource, so we'll skip the diagram this time.
 
 ## 🔍 Reference Manifests
 

--- a/content/09-helm-gateway-api/index.md
+++ b/content/09-helm-gateway-api/index.md
@@ -129,7 +129,7 @@ This command does the following:
   resources created by the chart, so it should be short and descriptive
 - `oci://ghcr.io/nginx/charts/nginx-gateway-fabric` - the location of the chart, in case it's a special type of remote
   URL
-- `--namespace nginx-gateway` - the namespace to install the NIGNX controler & proxy into
+- `--namespace nginx-gateway` - the namespace to install the NGINX controller & proxy into
 
 ## 🛠️ Configuring the Gateway
 
@@ -139,7 +139,7 @@ today we are wearing multiple hats!
 
 [📚 Gateway Resource](https://gateway-api.sigs.k8s.io/api-types/gateway/)
 
-Cretate a file called `gateway.yaml` with the following content:
+Create a file called `gateway.yaml` with the following content:
 
 ```yaml
 apiVersion: gateway.networking.k8s.io/v1

--- a/content/09a-helm-ingress/index.md
+++ b/content/09a-helm-ingress/index.md
@@ -25,7 +25,7 @@ So far we've worked in a single _Namespace_ called `default`, but Kubernetes all
 in order to logically group and separate your resources.
 
 Namespaces do not provide any form of network boundary or isolation of workloads, and the underlying resources (Nodes)
-remain shared. There are ways to achieve higher degress of isolation, but it is a matter well beyond the scope of this
+remain shared. There are ways to achieve higher degrees of isolation, but it is a matter well beyond the scope of this
 workshop. But they still provide a useful way to separate resources, and in this section we'll create a new namespace
 for the ingress resources, so that they are separate from the application resources.
 

--- a/content/10-extra-advanced/index.md
+++ b/content/10-extra-advanced/index.md
@@ -1,7 +1,7 @@
 ---
 index: 10
 title: Scaling & Stateful Workloads
-summary: Scaling (manual & auto), stateful workloads, persitent volumes, plus more Helm.
+summary: Scaling (manual & auto), stateful workloads, persistent volumes, plus more Helm.
 layout: default.njk
 icon: ⚖️
 tags: section

--- a/content/13-gitops-flux/index.md
+++ b/content/13-gitops-flux/index.md
@@ -140,7 +140,7 @@ Some points to highlight:
 - The _Kustomization_ adds a suffix to the names of resources.
 - Also the _Kustomization_ changes the image tag to reference a specific tag.
 - The patch `override.yaml` file looks a little like a regular Kubernetes _Deployment_ but it only contains the part
-  that will be patched/overlayed onto the base resource. On its own it's not a valid manifest.
+  that will be patched/overlaid onto the base resource. On its own it's not a valid manifest.
   - The patch file sets fields in the base _Deployment_ such as changing the resource limits and adding an extra
     environmental variable.
 
@@ -283,7 +283,7 @@ which was `gitops/apps` directory. The contents of the whole of the `gitops/` di
 ```
 
 The key thing about this structure is the `gitops/base` directory provides us a set of Kustomization-based resources we
-can use, but as it's outside of the `gitops/apps` path they will not auotmatically be picked up by Flux, until we create
+can use, but as it's outside of the `gitops/apps` path they will not automatically be picked up by Flux, until we create
 a Kustomization under `gitops/apps` that references them.
 
 ⚠️ **STOP!** Before we proceed, ensure the `database-creds` _Secret_ from the previous sections is still in the default


### PR DESCRIPTION
## Summary

Corrects spelling mistakes and typos across several workshop content pages. No functional or structural changes, content only.

## Changes

| File | Fix |
| --- | --- |
| [content/04-deployment/index.md](content/04-deployment/index.md) | `folowed` → `followed` |
| [content/07-improvements/index.md](content/07-improvements/index.md) | `datbase` → `database`, `encypted` → `encrypted`, `priviledges` → `privileges`, `Desptite` → `Despite` |
| [content/09-helm-gateway-api/index.md](content/09-helm-gateway-api/index.md) | `NIGNX controler` → `NGINX controller`, `Cretate` → `Create` |
| [content/09a-helm-ingress/index.md](content/09a-helm-ingress/index.md) | `degress` → `degrees` |
| [content/10-extra-advanced/index.md](content/10-extra-advanced/index.md) | `persitent` → `persistent` |
| [content/13-gitops-flux/index.md](content/13-gitops-flux/index.md) | `overlayed` → `overlaid`, `auotmatically` → `automatically` |
